### PR TITLE
Handle errors when repo lacks tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ config :versioce, :changelog,
 ```
 > Anchors definition should follow the `Versioce.Changelog.Anchors` struct format. As it will be converted to it down the line.
 
-And your are all set!
+And you're all set!
 Now you can either run a `mix changelog` task to generate a changelog file
 or add `Versioce.PostHooks.Changelog` post hook in your configuration:
 ``` elixir

--- a/lib/Changelog/DataGrabbers/git_datagrabber.ex
+++ b/lib/Changelog/DataGrabbers/git_datagrabber.ex
@@ -13,7 +13,8 @@ defmodule Versioce.Changelog.DataGrabber.Git do
 
   @impl Versioce.Changelog.DataGrabber
   def get_data(new_version \\ "HEAD") do
-    with true <- Utils.deps_loaded?([Git]) do
+    with true <- Utils.deps_loaded?([Git]),
+         [_tags] <- VGit.get_tags() do
       {
         :ok,
         new_version
@@ -22,6 +23,9 @@ defmodule Versioce.Changelog.DataGrabber.Git do
         |> prepare_group_sections(Config.Changelog.anchors())
       }
     else
+      [] ->
+        {:error, "No project tags found, please tag your release"}
+
       false ->
         {:error,
          "Optional dependency `git_cli` is not loaded. It is required for Git Datagrabber"}

--- a/lib/Changelog/DataGrabbers/git_datagrabber.ex
+++ b/lib/Changelog/DataGrabbers/git_datagrabber.ex
@@ -14,7 +14,7 @@ defmodule Versioce.Changelog.DataGrabber.Git do
   @impl Versioce.Changelog.DataGrabber
   def get_data(new_version \\ "HEAD") do
     with true <- Utils.deps_loaded?([Git]),
-         [_tags] <- VGit.get_tags() do
+         [_h | _t] <- VGit.get_tags() do
       {
         :ok,
         new_version

--- a/lib/Changelog/DataGrabbers/git_datagrabber.ex
+++ b/lib/Changelog/DataGrabbers/git_datagrabber.ex
@@ -14,7 +14,7 @@ defmodule Versioce.Changelog.DataGrabber.Git do
   @impl Versioce.Changelog.DataGrabber
   def get_data(new_version \\ "HEAD") do
     with true <- Utils.deps_loaded?([Git]),
-         [_h | _t] <- VGit.get_tags() do
+         [_tags] <- VGit.get_tags() do
       {
         :ok,
         new_version


### PR DESCRIPTION
First matcher only worked with a single tag